### PR TITLE
Make $9D PostByte PC offset calc to be same as $8D

### DIFF
--- a/f9dasm.c
+++ b/f9dasm.c
@@ -2150,8 +2150,10 @@ if (T & 0x80)
       bGetLabel = !IS_CONST(PC);
       W = ARGWORD(PC);
       PC += 2;
-      /*sprintf(buf,"[%s,PC]", label_string(W, bGetLabel, (word)(PC - 2)));*/
-      sprintf(buf, "[%s,PCR]", label_string((word)(W + PC), bGetLabel, (word)(PC - 2)));
+      if ((W < 0x80) || (W >= 0xff80))
+        sprintf(buf, "[%s%s,PCR]", forceextendedaddr, label_string((word)(W + PC), bGetLabel, (word)(PC - 2)));
+      else
+        sprintf(buf, "[%s,PCR]", label_string((word)(W + PC), bGetLabel, (word)(PC - 2)));
       break;
     case 0x07:
       if(allow_6309_codes)

--- a/f9dasm.c
+++ b/f9dasm.c
@@ -1821,7 +1821,8 @@ if (T & 0x80)
       bSetLabel = !IS_CONST(PC);
       W = ARGWORD(PC); PC += 2;
       if (bSetLabel)
-        AddLabel(MI, W);
+        /*AddLabel(MI, W);*/
+        AddLabel(MI, (word)(W + PC));
       break;
     case 0x07:
     case 0x17:
@@ -2149,7 +2150,8 @@ if (T & 0x80)
       bGetLabel = !IS_CONST(PC);
       W = ARGWORD(PC);
       PC += 2;
-      sprintf(buf,"[%s,PC]", label_string(W, bGetLabel, (word)(PC - 2)));
+      /*sprintf(buf,"[%s,PC]", label_string(W, bGetLabel, (word)(PC - 2)));*/
+      sprintf(buf, "[%s,PCR]", label_string((word)(W + PC), bGetLabel, (word)(PC - 2)));
       break;
     case 0x07:
       if(allow_6309_codes)


### PR DESCRIPTION
I think $9D label (constant offset from PC, indirect) should be calculated as PC offset from the object code address, rather than just the address.
For instance, without this modification, f9dasm generated:
```
        LDA     [MFFF1,PC]               *E829: A6 9D FF F1    '....'
```
which I don't think is correct, since it does not use PC in calculating the label address.

After change:
```
        LDA     [ME81E,PCR]              *E829: A6 9D FF F1    '....'
```
which seems correct. However, I don't know much about 6809 assembly. Just that this compiles under lwasm, while the old version did not.