### PR TITLE
Makefile: Unix build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+#   Unix binaries built by Makefile
+/f9dasm
+/hex2bin
+/mot2bin

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,1 @@
+all: f9dasm hex2bin mot2bin

--- a/README.md
+++ b/README.md
@@ -1,4 +1,21 @@
-# f9dasm
+f9dasm
+======
+
 Disassembler for Motorola 6800/6801/6809 and Hitachi 6301/6303/6309 binaries
 
 The documentation can be found in f9dasm.htm
+
+
+Building
+--------
+
+`f9dasm`, `hex2bin` and `mot2bin` are command line tools written in
+fairly generic C that should compile on a wide range of systems.
+
+For Microsoft Visual Studio, `.dsp`, `.dsw`, `.sln`, and `.vcproj`
+files are provided.
+
+A `Makefile` is provided for Linux systems; this may also work on
+other systems using GNU Make. You'll need to make sure you have the
+appropriate development packages (`make`, `gcc`, etc.) installed. This
+was tested on Debian 9.


### PR DESCRIPTION
This is fairly trivial, but both saves developers a bit of work to
figure out how to build this by and and lets Linux users know before
they download this that it should build and run on their system.
README updates mentioning the build configuration files are included.

Tested on Debian 9.