### PR TITLE
Print characters 'c with high bit set as 'c|$80; bump version

### DIFF
--- a/f9dasm.c
+++ b/f9dasm.c
@@ -124,9 +124,12 @@
                     See
                      https://github.com/Arakula/f9dasm/issues/24
                     for details.
+   V1.84 2024-09-28 Print characters 'c with high bit set as 'c|$80 (AS/A09-compatible)
+                    (Orig. added 2019-07-27 in alternate 1.79 version.)
+
 */
 
-#define ID  "1.83"
+#define ID  "1.84"
 
 #if RB_VARIANT
 #define VERSION ID "-RB"
@@ -1930,7 +1933,14 @@ if ((nDigits == 2) &&                   /* if 2-digit value                  */
     sprintf(s, "'%c", W);
 #endif
   else
-    sprintf(s, "$%02x", W);
+    if (isprint(W & 0x7f))
+#if RB_VARIANT
+      sprintf(s, "'%c'|$80", W & 0x7f);
+#else
+      sprintf(s, "'%c|$80", W & 0x7f);
+#endif
+    else
+      sprintf(s, "$%02x", W);
   }
 else if (IS_BINARY(addr))               /* if a binary                       */
   {


### PR DESCRIPTION
This is very useful for programs that set the high bit of characters
to indicate end of string or for some other reason. Sample output:

    FCB     'E,'N,'D|$80             ;015C: 45 4E C4       'EN.'

This applies only to memory locations explicitly marked as `char`
(in the info file). If you're doing a disassembly later to be
assembled by an assembler that doesn't support this "logical or"
syntax you can either not mark those bytes as `char` or, if you've
marked a large range like `char 015C-0233`, add additional directives
after that to mark individual bytes as non-char, e.g., `hex 015E` to
would produce `$C4` instead of `'D|$80` in the output above.

This syntax is supported by AS and A09, but does not appear to be
supported by TSC.

-----

This is related to issue #7, which includes an old (and somewhat incorrect) version of this patch. While there were some thoughts there about how to expand this feature, at the moment there seems to be no particular demand for anything beyond what this does now.