### PR TITLE
Fixed off-by-one strncmp in f9dasm.c

### DIFF
--- a/f9dasm.c
+++ b/f9dasm.c
@@ -3021,7 +3021,7 @@ if (!strcmp(I,"RTI") ||
     (!strncmp(I, "PUL", 3) && (T & 0x80)) ||  /* PULx PC */
     !strncmp(I, "JMP", 3) ||
     !strncmp(I, "BRA", 3) ||
-    !strncmp(I," SWI", 3) )
+    !strncmp(I, "SWI", 3) )
   optdelimbar = TRUE;
 
 return (PC - pc);


### PR DESCRIPTION
This was found with a "cstrnfinder" research and I haven't tested this change (more info https://twitter.com/disconnect3d_pl/status/1339757359896408065). Close this PR if this change is incorrect.