### PR TITLE
Allow '*' in comments.

### DIFF
--- a/f9dasm.c
+++ b/f9dasm.c
@@ -4722,7 +4722,7 @@ while (fgets(szBuf, sizeof(szBuf), fp))
         nTo = nFrom;
       for (q = p;
            (*q) &&
-           (*q != '\n') && (*q != '*');
+           (*q != '\n');
            q++)
         {
         if (*q == '\\')                 /* process escape character          */


### PR DESCRIPTION
I used '\*' in a comment and noticed that the comment was truncated after the '\*'.  This fixes it.
Thanks for the code!